### PR TITLE
Add Accept and Content-Format request mode support

### DIFF
--- a/coap.c
+++ b/coap.c
@@ -65,12 +65,12 @@ static void _option_decode(const uint32_t value, uint8_t *delta)
 bool _handle_specific_content_format(coap_resource_t *rs, const coap_option_t *opt, 
     const coap_packet_t *inpkt, coap_packet_t *pkt)
 {
-    // TODO: make this debug-only
-    /*
+#if YACOAP_DEBUG
     printf("Reaching CONTENT-FORMAT handler: %x.%x == %x.%x / len %d\r\n", 
         opt->buf.p[0], opt->buf.p[1],
         rs->content_type[0], rs->content_type[1],
-        opt->buf.len); */
+        opt->buf.len);
+#endif
 
     if(opt->buf.p[0] == rs->content_type[1])
     {

--- a/coap.h
+++ b/coap.h
@@ -284,6 +284,7 @@ struct coap_resource
     coap_resource_handler handler;      //!< callback function for method
     const coap_resource_path_t *path;   //!< resource path, e.g. foo/bar/
     const uint8_t content_type[2];      //!< content type of response
+    const char* attributes;             //!< link target attribute values (http://www.iana.org/assignments/core-parameters/core-parameters.xhtml)
 };
 
 /**


### PR DESCRIPTION
Adding features described in specification sections:

https://tools.ietf.org/html/rfc7252#section-5.10.3
https://tools.ietf.org/html/rfc7252#section-5.10.4

Also beefing up coap_make_link_format code to accommodate additional format types, when used 